### PR TITLE
Handle persistent auras with multiple stacks

### DIFF
--- a/helper.lua
+++ b/helper.lua
@@ -129,7 +129,11 @@ function MaxDps:UnitAura(auraId, timeShift, unit, filter)
 
 		return true, aura.count, cd;
 	elseif aura.expirationTime == 0 then
-		return true, 1, 99999; -- Persistent auras
+		local count = 1;
+		if aura.count > 0 then
+			count = aura.count;
+		end
+		return true, count, 99999; -- Persistent auras
 	end
 
 	return false, 0, 0;


### PR DESCRIPTION
Most persistent auras have an internal count of zero, and they are correctly represented as having a single stack.  But for persistent auras that can stack multiple times, the actual stack count should be returned.