### PR TITLE
Add essences to FrameData

### DIFF
--- a/core.lua
+++ b/core.lua
@@ -229,6 +229,7 @@ function MaxDps:PrepareFrameData()
 	self.FrameData.buff, self.FrameData.debuff = MaxDps:CollectAuras();
 	self.FrameData.talents = self.PlayerTalents;
 	self.FrameData.azerite = self.AzeriteTraits;
+	self.FrameData.essences = self.AzeriteEssences;
 	self.FrameData.spellHistory = self.spellHistory;
 	self.FrameData.timeToDie = self:GetTimeToDie();
 end


### PR DESCRIPTION
I'm assuming the intention of the past few changes were working towards having essences exposed for custom rotations. I have this patched locally and can test for and highlight essences I use on cooldown. 