### PR TITLE
Add support for LAB forks

### DIFF
--- a/buttons.lua
+++ b/buttons.lua
@@ -95,40 +95,44 @@ function MaxDps:ApplyOverlayChanges()
 	end
 end
 
-function MaxDps:UpdateButtonGlow()
+do
 	local origShow;
-	local noFunction = function() end;
 
-	local LBG = LibStub('LibButtonGlow-1.0', true);
-	if LBG then
-		origShow = LBG.ShowOverlayGlow;
-	end
+	function MaxDps:UpdateButtonGlow()
+		if self.db.global.disableButtonGlow then
+			ActionBarActionEventsFrame:UnregisterEvent('SPELL_ACTIVATION_OVERLAY_GLOW_SHOW');
 
-	if self.db.global.disableButtonGlow then
-		ActionBarActionEventsFrame:UnregisterEvent('SPELL_ACTIVATION_OVERLAY_GLOW_SHOW');
-
-		for LAB in pairs(LABs) do
-			local lib = LibStub(LAB, true);
-			if lib then
-				lib.eventFrame:UnregisterEvent('SPELL_ACTIVATION_OVERLAY_GLOW_SHOW');
+			for LAB in pairs(LABs) do
+				local lib = LibStub(LAB, true);
+				if lib then
+					lib.eventFrame:UnregisterEvent('SPELL_ACTIVATION_OVERLAY_GLOW_SHOW');
+				end
 			end
-		end
 
-		if LBG then
-			LBG.ShowOverlayGlow = noFunction;
-		end
-	else
-		ActionBarActionEventsFrame:RegisterEvent('SPELL_ACTIVATION_OVERLAY_GLOW_SHOW');
-
-		for LAB in pairs(LABs) do
-			local lib = LibStub(LAB, true);
-			if lib then
-				lib.eventFrame:RegisterEvent('SPELL_ACTIVATION_OVERLAY_GLOW_SHOW');
+			if not origShow then
+				local LBG = LibStub('LibButtonGlow-1.0', true);
+				if LBG then
+					origShow = LBG.ShowOverlayGlow;
+					LBG.ShowOverlayGlow = nop;
+				end
 			end
-		end
+		else
+			ActionBarActionEventsFrame:RegisterEvent('SPELL_ACTIVATION_OVERLAY_GLOW_SHOW');
 
-		if LBG then
-			LBG.ShowOverlayGlow = origShow;
+			for LAB in pairs(LABs) do
+				local lib = LibStub(LAB, true);
+				if lib then
+					lib.eventFrame:RegisterEvent('SPELL_ACTIVATION_OVERLAY_GLOW_SHOW');
+				end
+			end
+
+			if origShow then
+				local LBG = LibStub('LibButtonGlow-1.0', true);
+				if LBG then
+					LBG.ShowOverlayGlow = origShow;
+					origShow = nil;
+				end
+			end
 		end
 	end
 end

--- a/buttons.lua
+++ b/buttons.lua
@@ -8,6 +8,11 @@ MaxDps.SpellsGlowing = {};
 MaxDps.FramePool = {};
 MaxDps.Frames = {};
 
+local LABs = {
+	['LibActionButton-1.0'] = true,
+	['LibActionButton-1.0-ElvUI'] = true,
+};
+
 --- Creates frame overlay over a specific frame, it doesn't need to be a button.
 -- @param parent - frame that is suppose to be attached to
 -- @param id - string id of overlay because frame can have multiple overlays
@@ -91,23 +96,22 @@ function MaxDps:ApplyOverlayChanges()
 end
 
 function MaxDps:UpdateButtonGlow()
-	local LAB;
-	local LBG;
 	local origShow;
 	local noFunction = function() end;
 
-	if IsAddOnLoaded('ElvUI') then
-		LAB = LibStub:GetLibrary('LibActionButton-1.0-ElvUI');
-		LBG = LibStub:GetLibrary('LibButtonGlow-1.0');
+	local LBG = LibStub('LibButtonGlow-1.0', true);
+	if LBG then
 		origShow = LBG.ShowOverlayGlow;
-	elseif IsAddOnLoaded('Bartender4') then
-		LAB = LibStub:GetLibrary('LibActionButton-1.0');
 	end
 
 	if self.db.global.disableButtonGlow then
 		ActionBarActionEventsFrame:UnregisterEvent('SPELL_ACTIVATION_OVERLAY_GLOW_SHOW');
-		if LAB then
-			LAB.eventFrame:UnregisterEvent('SPELL_ACTIVATION_OVERLAY_GLOW_SHOW');
+
+		for LAB in pairs(LABs) do
+			local lib = LibStub(LAB, true);
+			if lib then
+				lib.eventFrame:UnregisterEvent('SPELL_ACTIVATION_OVERLAY_GLOW_SHOW');
+			end
 		end
 
 		if LBG then
@@ -115,8 +119,12 @@ function MaxDps:UpdateButtonGlow()
 		end
 	else
 		ActionBarActionEventsFrame:RegisterEvent('SPELL_ACTIVATION_OVERLAY_GLOW_SHOW');
-		if LAB then
-			LAB.eventFrame:RegisterEvent('SPELL_ACTIVATION_OVERLAY_GLOW_SHOW');
+
+		for LAB in pairs(LABs) do
+			local lib = LibStub(LAB, true);
+			if lib then
+				lib.eventFrame:RegisterEvent('SPELL_ACTIVATION_OVERLAY_GLOW_SHOW');
+			end
 		end
 
 		if LBG then
@@ -360,17 +368,22 @@ function MaxDps:FetchSyncUI()
 	end
 end
 
-function MaxDps:FetchLibActionButton()
-	local LAB = {
-		original = LibStub:GetLibrary('LibActionButton-1.0', true),
-		elvui = LibStub:GetLibrary('LibActionButton-1.0-ElvUI', true),
-	}
+function MaxDps:RegisterLibActionButton(name)
+	assert(type(name) == 'string', format('Bad argument to "RegisterLibActionButton", expected string, got "%s"', type(name)));
 
-	for _, lib in pairs(LAB) do
-		if lib and lib.GetAllButtons then
+	if not name:match('LibActionButton%-1%.0') then
+		error(format('Bad argument to "RegisterLibActionButton", expected "LibActionButton-1.0*", got "%s"', name), 2);
+	end
+
+	LABs[name] = true;
+end
+
+function MaxDps:FetchLibActionButton()
+	for LAB in pairs(LABs) do
+		local lib = LibStub(LAB, true);
+		if lib then
 			for button in pairs(lib:GetAllButtons()) do
-				local spellId = button:GetSpellId();
-				self:AddButton(spellId, button);
+				self:AddButton(button:GetSpellId(), button);
 			end
 		end
 	end

--- a/core.lua
+++ b/core.lua
@@ -73,6 +73,7 @@ function MaxDps:EnableRotation()
 	end
 
 	self:Fetch();
+	self:UpdateButtonGlow();
 
 	self:CheckTalents();
 	self:GetAzeriteTraits();
@@ -115,7 +116,7 @@ function MaxDps:OnEnable()
 	self:RegisterEvent('PLAYER_TARGET_CHANGED');
 	self:RegisterEvent('PLAYER_TALENT_UPDATE');
 	self:RegisterEvent('PLAYER_REGEN_DISABLED');
-	self:RegisterEvent('PLAYER_ENTERING_WORLD');
+	-- self:RegisterEvent('PLAYER_ENTERING_WORLD');
 	self:RegisterEvent('AZERITE_ESSENCE_ACTIVATED');
 
 	self:RegisterEvent('ACTIONBAR_SLOT_CHANGED', 'ButtonFetch');
@@ -188,10 +189,6 @@ function MaxDps:UNIT_EXITED_VEHICLE(event, unit)
 		self:InitRotations();
 		self:EnableRotation();
 	end
-end
-
-function MaxDps:PLAYER_ENTERING_WORLD()
-	self:UpdateButtonGlow();
 end
 
 function MaxDps:PLAYER_TARGET_CHANGED()

--- a/options.lua
+++ b/options.lua
@@ -139,7 +139,10 @@ function MaxDps:AddToBlizzardOptions()
 
 	local disableButtonGlow = StdUi:Checkbox(optionsFrame, 'Dissable blizzard button glow (experimental)', 200, 24);
 	disableButtonGlow:SetChecked(MaxDps.db.global.disableButtonGlow);
-	disableButtonGlow.OnValueChanged = function(_, flag) MaxDps.db.global.disableButtonGlow = flag; end;
+	disableButtonGlow.OnValueChanged = function(_, flag)
+		MaxDps.db.global.disableButtonGlow = flag;
+		MaxDps:UpdateButtonGlow();
+	end;
 
 	local interval = StdUi:SliderWithBox(optionsFrame, 100, 48, MaxDps.db.global.interval, 0.01, 2);
 	interval:SetPrecision(2);


### PR DESCRIPTION
Sup o/

Some of my UI users use this addon, but my UI relies on my own fork of LAB. ~~Yeah, yet another LAB fork, there's quite many these days.~~

So instead of hooking your `FetchLibActionButton` and `UpdateButtonGlow` methods or nagging you to add support for other forks, I decided to add `RegisterLibActionButton` method, so other people could register their LABs w/ your addon, so it could work w/ their buttons w/o any hassle. 

Some time ago I did something similar for [AdiButtonAuras](https://github.com/AdiAddons/AdiButtonAuras/pull/315). I rewrote all affected functions, primarily aforementioned `FetchLibActionButton` and `UpdateButtonGlow`. I also tried to follow your style, so it should look fine :D

Ah, and regarding `UpdateButtonGlow`, I fixed its logic, there's an issue where `origShow`'s state wasn't saved across calls, so you could actually end up w/ it being `noFunction` or now `nop`, `nop` is a [Blizz func](https://github.com/Gethe/wow-ui-source/blob/live/FrameXML/UIParent.lua#L5188-L5189). And it wasn't updated when you toggled the "Disable blizzard button glow" thingy. I also removed `UpdateButtonGlow` from `PEW` and moved it to `EnableRotation`. You could probably remove "experimental" from it, but keep it disabled by default 🤔 

If you want, I can move all glow changes to their own PR.