### PR TITLE
Updated MaxDps:CheckTalents in Helper.lua 

### DIFF
--- a/Helper.lua
+++ b/Helper.lua
@@ -212,15 +212,30 @@ end
 
 function MaxDps:CheckTalents()
 	self.PlayerTalents = {};
+    
+    -- last selected configID or fall back to default spec config
+    local configID = C_ClassTalents.GetActiveConfigID();
+    
+    local configInfo = C_Traits.GetConfigInfo(configID);
+    local treeID = configInfo.treeIDs[1];
 
-	for talentRow = 1, 7 do
-		for talentCol = 1, 3 do
-			local _, _, _, sel, _, id = GetTalentInfo(talentRow, talentCol, 1);
-			if sel then
-				self.PlayerTalents[id] = 1;
-			end
-		end
-	end
+    local nodes = C_Traits.GetTreeNodes(treeID);
+
+    for _, nodeID in ipairs(nodes) do
+        local nodeInfo = C_Traits.GetNodeInfo(configID, nodeID)
+        if nodeInfo.currentRank and nodeInfo.currentRank > 0 then
+            local entryID = nodeInfo.activeEntry and nodeInfo.activeEntry.entryID and nodeInfo.activeEntry.entryID;
+            local entryInfo = entryID and C_Traits.GetEntryInfo(configID, entryID);
+            local definitionInfo = entryInfo and entryInfo.definitionID and C_Traits.GetDefinitionInfo(entryInfo.definitionID);
+
+            if definitionInfo ~= nil then
+				self.PlayerTalents[definitionInfo.spellID] = 1;
+				--local talentName = TalentUtil.GetTalentName(definitionInfo.overrideName, definitionInfo.spellID);
+                --print(string.format("%s %d", talentName, definitionInfo.spellID));
+            end
+        end
+    end
+
 end
 
 MaxDps.isMelee = false;

--- a/Helper.lua
+++ b/Helper.lua
@@ -212,30 +212,27 @@ end
 
 function MaxDps:CheckTalents()
 	self.PlayerTalents = {};
-    
-    -- last selected configID or fall back to default spec config
+	
+	-- last selected configID or fall back to default spec config
     local configID = C_ClassTalents.GetActiveConfigID();
-    
     local configInfo = C_Traits.GetConfigInfo(configID);
-    local treeID = configInfo.treeIDs[1];
+    local treeIDs = configInfo.treeIDs;
+	
+	for _, treeID in ipairs(treeIDs) do
+		local nodes = C_Traits.GetTreeNodes(treeID);
+		for _, nodeID in ipairs(nodes) do
+			local nodeInfo = C_Traits.GetNodeInfo(configID, nodeID)
+			if nodeInfo.currentRank and nodeInfo.currentRank > 0 then
+				local entryID = nodeInfo.activeEntry and nodeInfo.activeEntry.entryID and nodeInfo.activeEntry.entryID;
+				local entryInfo = entryID and C_Traits.GetEntryInfo(configID, entryID);
+				local definitionInfo = entryInfo and entryInfo.definitionID and C_Traits.GetDefinitionInfo(entryInfo.definitionID);
 
-    local nodes = C_Traits.GetTreeNodes(treeID);
-
-    for _, nodeID in ipairs(nodes) do
-        local nodeInfo = C_Traits.GetNodeInfo(configID, nodeID)
-        if nodeInfo.currentRank and nodeInfo.currentRank > 0 then
-            local entryID = nodeInfo.activeEntry and nodeInfo.activeEntry.entryID and nodeInfo.activeEntry.entryID;
-            local entryInfo = entryID and C_Traits.GetEntryInfo(configID, entryID);
-            local definitionInfo = entryInfo and entryInfo.definitionID and C_Traits.GetDefinitionInfo(entryInfo.definitionID);
-
-            if definitionInfo ~= nil then
-				self.PlayerTalents[definitionInfo.spellID] = 1;
-				--local talentName = TalentUtil.GetTalentName(definitionInfo.overrideName, definitionInfo.spellID);
-                --print(string.format("%s %d", talentName, definitionInfo.spellID));
-            end
-        end
-    end
-
+				if definitionInfo ~= nil then
+					self.PlayerTalents[definitionInfo.spellID] = 1;
+				end
+			end
+		end
+	end
 end
 
 MaxDps.isMelee = false;

--- a/MaxDps.toc
+++ b/MaxDps.toc
@@ -1,8 +1,8 @@
 ## Title: MaxDps
 ## Notes: Rotation helper framework.
-## Version: 9.1.5
+## Version: 10.0.0
 ## Author: Kaminaris
-## Interface: 90105
+## Interface: 100000
 ## SavedVariables: MaxDpsOptions
 ## OptionalDependencies: Bartender4, ElvUI, ButtonForge, SVUI_ActionBars, G15Buttons, SyncUI, LUI, Dominos, DiabolicUI, Neuron
 ## X-Curse-Project-ID: 91970


### PR DESCRIPTION
Updated the method to remove the reference to the old talent tree (code still pulled data but it was the old hidden talents) and added code to pull talents based on the new trees in dragonflight. 

Note that this populates selected talents not taking x/y point entries into consideration as no tracking for that currently exists in MaxDPS. 

Tested to ensure selected talents are captured and that non-selected talents are not captured. Verified with standard talents and the choice ones. 