### PR TITLE
ShadowWordPain added for Discipline Priests

### DIFF
--- a/Core.lua
+++ b/Core.lua
@@ -3849,6 +3849,7 @@ function MaxDps:UpdateSpellsAndTalents()
 				["BrightPupil"] = 390684,
 				["Fade"] = 586,
 				["Sanlayn"] = 199855,
+				["ShadowWordPain"] = 589,
 				["FromDarknessComesLight"] = 390615,
 				["Apathy"] = 390668,
 				["ProtectiveLight"] = 193063,


### PR DESCRIPTION
This change fixes the Invalid spell slot error thrown by Helper.lua when ShadowWordPain is called by Discipline.lua ln. 86-88 (ST) and ln. 124-126 (MT). Shadow Word Pain is not defined for discipline priests in either Core.lua or Discipline.lua (likely because in most cases it will be replaced with Purge the Wicked). Because the spell is common across all three specializations, Core.lua seemed the best place to define the spellid.