### PR TITLE
Spell Alert Frame Enhancements

### DIFF
--- a/Modules/Window.lua
+++ b/Modules/Window.lua
@@ -511,9 +511,26 @@ function Window:GetWindowConfig()
 				enabled = {
 					type = 'checkbox',
 					label = 'Enable',
+					column = 6,
+					order = 1,
 					initialValue = MaxDps.db.global.spellFrame.enabled,
 					onValueChanged = function(_, flag)
 						MaxDps.db.global.spellFrame.enabled = flag
+						--MaxDps:UpdateSpellFrame(MaxDps.Spell or 116)
+					end
+				},
+				isMovable = {
+					type = 'checkbox',
+					label = 'Unlock',
+					column = 6,
+					order = 2,
+					initialValue = MaxDps.db.global.spellFrame.isMovable,
+					onValueChanged = function(_, flag)
+						MaxDps.db.global.spellFrame.isMovable = flag
+						if MaxDpsSpellFrame then
+							MaxDpsSpellFrame:SetMouseClickEnabled(MaxDps.db.global.spellFrame.isMovable)
+							MaxDpsSpellFrame:SetMovable(MaxDps.db.global.spellFrame.isMovable)
+						end
 						--MaxDps:UpdateSpellFrame(MaxDps.Spell or 116)
 					end
 				}

--- a/Options.lua
+++ b/Options.lua
@@ -262,20 +262,30 @@ function MaxDps:AddToBlizzardOptions()
 		MaxDps.db.global.spellFrame.enabled = flag
 	end
 
+	local spellFrameMovable = StdUi:Checkbox(optionsFrame, 'Unlock spell frame', 200, 24)
+	spellFrameMovable:SetChecked(MaxDps.db.global.spellFrame.isMovable)
+	spellFrameMovable.OnValueChanged = function(_, flag)
+		MaxDps.db.global.spellFrame.isMovable = flag
+		if MaxDpsSpellFrame then
+			MaxDpsSpellFrame:SetMouseClickEnabled(MaxDps.db.global.spellFrame.isMovable)
+			MaxDpsSpellFrameself:SetMovable(MaxDps.db.global.spellFrame.isMovable)
+		end
+	end
+
 	local spellFramePosx = StdUi:SliderWithBox(optionsFrame, 100, 48, MaxDps.db.global.spellFrame.pos.x or 0, -2000, 2000)
-	StdUi:AddLabel(optionsFrame, spellFramePosx, 'x Possition')
+	StdUi:AddLabel(optionsFrame, spellFramePosx, 'x Position')
 	spellFramePosx.OnValueChanged = function(_, val) MaxDps.db.global.spellFrame.pos.x = val end
 
 	local spellFramePosy = StdUi:SliderWithBox(optionsFrame, 100, 48, MaxDps.db.global.spellFrame.pos.y or 0, -2000, 2000)
-	StdUi:AddLabel(optionsFrame, spellFramePosy, 'y Possition')
+	StdUi:AddLabel(optionsFrame, spellFramePosy, 'y Position')
 	spellFramePosy.OnValueChanged = function(_, val) MaxDps.db.global.spellFrame.pos.y = val end
 
 	local spellFrameSizex = StdUi:SliderWithBox(optionsFrame, 100, 48, MaxDps.db.global.spellFrame.size.x or 0, -2000, 2000)
-	StdUi:AddLabel(optionsFrame, spellFrameSizex, 'x Possition')
+	StdUi:AddLabel(optionsFrame, spellFrameSizex, 'x Position')
 	spellFrameSizex.OnValueChanged = function(_, val) MaxDps.db.global.spellFrame.size.x = val end
 
 	local spellFrameSizey = StdUi:SliderWithBox(optionsFrame, 100, 48, MaxDps.db.global.spellFrame.size.y or 0, -2000, 2000)
-	StdUi:AddLabel(optionsFrame, spellFrameSizey, 'y Possition')
+	StdUi:AddLabel(optionsFrame, spellFrameSizey, 'y Position')
 	spellFrameSizey.OnValueChanged = function(_, val) MaxDps.db.global.spellFrame.size.y = val end
 
 	--- Pixel Glow options
@@ -459,10 +469,26 @@ function MaxDps:AddSpellFrameOptions()
 				enabled = {
 					type = 'checkbox',
 					label = 'Enable',
+					column = 6,
+					order = 1,
 					initialValue = MaxDps.db.global.spellFrame.enabled,
 					onValueChanged = function(_, flag)
 						MaxDps.db.global.spellFrame.enabled = flag
 						--MaxDps:UpdateSpellFrame(MaxDps.Spell or 116)
+					end
+				},
+				isMovable = {
+					type = 'checkbox',
+					label = 'Unlock',
+					column = 6,
+					order = 2,
+					initialValue = MaxDps.db.global.spellFrame.isMovable,
+					onValueChanged = function(_, flag)
+						MaxDps.db.global.spellFrame.isMovable = flag
+						if MaxDpsSpellFrame then
+							MaxDpsSpellFrame:SetMouseClickEnabled(MaxDps.db.global.spellFrame.isMovable)
+							MaxDpsSpellFrame:SetMovable(MaxDps.db.global.spellFrame.isMovable)
+						end
 					end
 				}
 			},
@@ -497,7 +523,7 @@ function MaxDps:AddSpellFrameOptions()
 			[5] = {
 				x = {
 					type   = 'sliderWithBox',
-					label  = 'x possition',
+					label  = 'x position',
 					min    = -2000,
 					max    = 2000,
 					column = 6,
@@ -511,7 +537,7 @@ function MaxDps:AddSpellFrameOptions()
 			[6] = {
 				y = {
 					type   = 'sliderWithBox',
-					label  = 'y possition',
+					label  = 'y position',
 					min    = -2000,
 					max    = 2000,
 					column = 6,

--- a/SpellFrame.lua
+++ b/SpellFrame.lua
@@ -27,6 +27,18 @@ loader:SetScript("OnEvent", function(self, event, name)
         f:SetMouseMotionEnabled(true)
         f:SetMouseClickEnabled(cfg.isMovable)
     end) -- next frame, as frame engine ignores mouse setting at frame creation
+    local function SetTooltipHint(owner,cfg)
+        if not InCombatLockdown() and IsModifierKeyDown() then
+            GameTooltip:SetOwner(owner, "ANCHOR_RIGHT")
+            GameTooltip:SetText("MaxDps Spell Frame")
+            if cfg.isMovable then
+                GameTooltip:AddLine("Right-click to Lock")
+            else
+                GameTooltip:AddDoubleLine("Unlock from Options","/maxdps",nil,nil,nil,GRAY_FONT_COLOR:GetRGB())
+            end
+            GameTooltip:Show()
+        end
+    end
     f:SetScript("OnMouseDown", function(self, button)
         if button == "LeftButton" and cfg.isMovable then
             self:StartMoving()
@@ -60,24 +72,30 @@ loader:SetScript("OnEvent", function(self, event, name)
     f:SetScript("OnHide", function(self)
         self:StopMovingOrSizing()
         self.isMoving = false
+        self.isMouseOver = false
     end)
     f:SetScript("OnEnter", function(self)
-        if not InCombatLockdown() then
-            GameTooltip:SetOwner(self, "ANCHOR_RIGHT")
-            GameTooltip:SetText("MaxDps Spell Frame")
-            if cfg.isMovable then
-                GameTooltip:AddLine("Right-click to Lock")
-            else
-                GameTooltip:AddLine("Unlock from Options")
-            end
-            GameTooltip:Show()
-        end
+        self.isMouseOver = true
+        SetTooltipHint(self,cfg)
     end)
     f:SetScript("OnLeave", function(self)
+        self.isMouseOver = false
         if GameTooltip:IsOwned(self) then
             GameTooltip_Hide()
         end
     end)
+    f:SetScript("OnEvent", function(self,event,key,down)
+        if self.isMouseOver then
+            if down == 1 then
+                SetTooltipHint(self,cfg)
+            else
+                if GameTooltip:IsOwned(self) then
+                    GameTooltip_Hide()
+                end
+            end
+        end
+    end)
+    f:RegisterEvent("MODIFIER_STATE_CHANGED")
     f:SetBackdrop({
         bgFile = "Interface/Buttons/WHITE8x8",
         edgeFile = "Interface/Buttons/WHITE8x8",


### PR DESCRIPTION
- locking spell alert frame disables mouse capture
- locking / unlocking spell alert frame moved to options
  - tooltip hint (out of combat) for spell alert frame when a modifier is held
  - quick lock option with right-click when unlocked